### PR TITLE
Fix Build by moveing to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 
 # Copy only the necessary runtime files
 COPY --from=builder /app/.next ./.next
-COPY --from=builder /app/public ./public
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/node_modules ./node_modules
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,5 @@ COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/node_modules ./node_modules
 
-# Create non-root user
-RUN addgroup --system nodejs && adduser --system --ingroup nodejs nodejs
-USER nodejs
-
 EXPOSE 3000
 CMD ["pnpm", "start"]

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,3 +1,15 @@
-[deploy.envs]
-NODE_ENV = "production"
-NIXPACKS_NODE_VERSION = 22
+[phases.setup]
+
+nixPkgs = ['nodejs_20']
+
+[phases.install]
+
+cmds = ['pnpm ci']
+
+[phases.build]
+
+cmds = ['pnpm run build']
+
+[start]
+
+cmd = 'pnpm run start'

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,10 +1,10 @@
 [phases.setup]
 
-nixPkgs = ['nodejs_20']
+nixPkgs = ['nodejs_20', "pnpm"]
 
 [phases.install]
 
-cmds = ['pnpm ci']
+cmds = ["pnpm install --frozen-lockfile"]
 
 [phases.build]
 


### PR DESCRIPTION
This pull request updates deployment configuration files to streamline the build and runtime environments for the application. The main changes involve switching the Node.js version used for builds, updating the package manager configuration, and removing the non-root user setup from the Dockerfile.

Deployment and build configuration updates:

* Replaced the previous environment variable-based configuration in `nixpacks.toml` with explicit phase definitions, switched Node.js to version 20, and specified `pnpm` as the package manager. Build and install commands are now clearly defined in the setup, install, and build phases.

Dockerfile simplification:

* Removed the creation and use of a non-root `nodejs` user in the Dockerfile, so the container now runs as root by default.
* Removed the copying of the `public` directory from the builder stage in the Dockerfile, potentially reducing the image size or changing runtime file availability.